### PR TITLE
chore: add missing vscjava.vscode-java-debug and vscjava.vscode-java-test extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,8 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "redhat.java",
-    "redhat.dependency-analytics"
+    "vscjava.vscode-java-debug",
+    "vscjava.vscode-java-test",
+    "redhat.fabric8-analytics"
   ]
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/devspaces-samples/lombok-project-sample/pull/3

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

This pull request
- adds missing `vscjava.vscode-java-debug` and `vscjava.vscode-java-test` extensions
- uses proper identifier for `redhat.fabric8-analytics` extension

Solves https://issues.redhat.com/browse/CRW-3302, https://issues.redhat.com/browse/CRW-3216

Use following URI to create a workspace with factory
https://github.com/vitaliy-guliy/lombok-project-sample?che-editor=che-incubator/che-code/insiders
