### PR TITLE
set devfile's schemaVersion to 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: java-lombok
 components:


### PR DESCRIPTION
Updates devfile's schemaVersion to 2.2.2

Related issue: https://github.com/eclipse/che/issues/21985

![screenshot-devspaces apps sandbox-stage gb17 p1 openshiftapps com-2024 02 01-15_40_36](https://github.com/devspaces-samples/lombok-project-sample/assets/1271546/043190a6-b444-4220-bbbe-537bf6524260)

